### PR TITLE
Add blank page when loading

### DIFF
--- a/components/Navigation/Navigation.tsx
+++ b/components/Navigation/Navigation.tsx
@@ -66,6 +66,9 @@ const Navigation = (props: { className?: string }) => {
     }
 
     Router.events.on('routeChangeStart', handleRouteChange)
+    return () => {
+      Router.events.off('routeChangeStart', handleRouteChange)
+    }
   }, [])
 
   return (

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,0 +1,21 @@
+import { AppProps } from 'next/app'
+import { useEffect, useState } from 'react'
+import { Router } from 'next/router'
+
+export default function App({ Component, pageProps }: AppProps) {
+  const [isLoading, setIsLoading] = useState(false)
+
+  useEffect(() => {
+    const handleRouteChangeStart = () => {
+      setIsLoading(true)
+    }
+    const handleRouteChangeEnd = () => {
+      setIsLoading(false)
+    }
+
+    Router.events.on('routeChangeStart', handleRouteChangeStart)
+    Router.events.on('routeChangeComplete', handleRouteChangeEnd)
+    Router.events.on('routeChangeError', handleRouteChangeEnd)
+  }, [])
+  return isLoading ? null : <Component {...pageProps} />
+}


### PR DESCRIPTION
Client side navigation is slow for some reason
the first migitation is to add a blank screen so we
can at least see somethig is happenig

We could make this look better though…
also we schoul improve the page loading speed

fixes: #12